### PR TITLE
Typo in add-entry function in Namespaces section

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -728,7 +728,7 @@ that looks like:
    [journal.utils :as utils]))
 
 (defn add-entry
-  [opts]
+  [{:keys [opts]}]
   (let [entries (utils/read-entries)]
     (spit utils/ENTRIES-LOCATION
           (conj entries


### PR DESCRIPTION
In the `Organizing your project -> Namespaces` section the `add-entry` function has lost its `{:keys [opts]}` destructuring.

Edit: This gets sorted out by the subsequent changes to the dispatch table, after adding the `list` function.
But at the point that the text says:
> If you call ./journal add -e "visited by the tooth fairy, except he was a
balding 45-year-old man with a potbelly from Brooklyn", it should still work.

it doesn't actually work; you end up writing `babashka.cli`'s full args map to the entries file:
```
[{:timestamp 1673261442050, :cmds ("add"), :args (), :rest-cmds (), :opts {:entry "visited by the tooth fairy, except he was a balding 45-year-old man with a potbelly from Brooklyn"}, :dispatch ["add"]}]
```